### PR TITLE
Fix access for scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
         "type": "git",
         "url": "https://github.com/pixijs/webworker-plugins.git"
     },
+    "publishConfig": {
+        "access": "public"
+    },
     "homepage": "https://github.com/pixijs/webworker-plugins",
     "bugs": "https://github.com/pixijs/webworker-plugins/issues",
     "files": [


### PR DESCRIPTION
This fix resolves this issue when attempting to publish:

```
npm ERR! code E402
npm ERR! 402 Payment Required - PUT https://registry.npmjs.org/@pixi%2fwebworker-plugins - You must sign up for private packages
```