### PR TITLE
Change Worker from inherit to member

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,7 +5,7 @@ export function buildWorkerCode(source: string, moduleType: ModuleType)
     let result = `\
 const WORKER_CODE = ${JSON.stringify(source)};
 let WORKER_URL = null;
-class WorkerInstance extends Worker
+class WorkerInstance
 {
     constructor()
     {
@@ -13,7 +13,7 @@ class WorkerInstance extends Worker
         {
             WORKER_URL = URL.createObjectURL(new Blob([WORKER_CODE], { type: 'application/javascript' }));
         }
-        super(WORKER_URL);
+        this.worker = new Worker(WORKER_URL);
     }
 }
 WorkerInstance.revokeObjectURL = function revokeObjectURL()

--- a/test/JestTransform.tests.ts
+++ b/test/JestTransform.tests.ts
@@ -1,6 +1,6 @@
 import AdderWorker from 'worker:./workers/Adder.worker.ts';
 
-describe('Test', () =>
+describe('JestTransform', () =>
 {
     it('should work', async () =>
         new Promise<void>((resolve) =>

--- a/test/JestTransform.tests.ts
+++ b/test/JestTransform.tests.ts
@@ -7,13 +7,13 @@ describe('Test', () =>
         {
             const worker = new AdderWorker();
 
-            worker.onmessage = (event) =>
+            worker.worker.onmessage = (event) =>
             {
                 expect(event.data).toBe(2);
                 resolve();
             };
 
-            worker.postMessage({ a: 1, b: 1 });
+            worker.worker.postMessage({ a: 1, b: 1 });
         })
     );
 });

--- a/test/NoWorker.tests.ts
+++ b/test/NoWorker.tests.ts
@@ -1,0 +1,23 @@
+import AdderWorker from 'worker:./workers/Adder.worker.ts';
+
+describe('NoWorker', () =>
+{
+    let savedWorker: typeof Worker;
+
+    beforeAll(() =>
+    {
+        savedWorker = globalThis.Worker;
+        // @ts-expect-error: remove Worker
+        delete globalThis.Worker;
+    });
+    afterAll(() =>
+    {
+        globalThis.Worker = savedWorker;
+    });
+
+    it('should throw if no Worker', () =>
+    {
+        expect(() => new AdderWorker()).toThrow(ReferenceError);
+    }
+    );
+});

--- a/test/global.d.ts
+++ b/test/global.d.ts
@@ -1,7 +1,9 @@
 declare module '*.worker.ts'
 {
-    class WorkerInstance extends Worker
+    class WorkerInstance
     {
+        public worker: Worker;
+
         constructor();
 
         static revokeObjectURL(): void;


### PR DESCRIPTION
`WorkerInstance` no longer extends `Worker`, instead make `Worker` a member of `WorkerInstance`. This way the generated code will not throw a `ReferenceError` when loading if `Worker` does not exist.